### PR TITLE
Fix AP triangulation, modernize UI, target ATAK 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,7 @@ Android dependencies and is unit-tested in `TrilaterationTest`.
 
 ## Building
 
-Targets **ATAK 5.7** (`ATAK_VERSION = 5.7.0`), AGP 8.7 / Gradle 8.14, Java 17,
-`compileSdk 36`.
+Targets **ATAK 5.7** (`ATAK_VERSION = 5.7.0`), AGP 8.9 / Gradle 8.14, Java 17,
+`compileSdk 36`. Signing falls back to the build-generated
+`${buildDir}/android_keystore` when no `local.properties` keys are present, so it
+builds unchanged on tak.gov/user_builds.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,42 @@
 # wifi2cot
- ATAK Plugin that grab RSSI values from local Access Points and try to plot where they are on the map.
 
-# Directions
- The operations are simple, press Start to begin scanning for WIFI Access Points (AP) the longer and the more you move around the area of interest the better. When ready, press Stop and then Compute. This will take all the AP measurement readings and try to triangluate where the AP is.
+ATAK plugin that samples RSSI from nearby Wi-Fi access points as you move, then
+estimates where each access point is and plots it as a CoT marker.
 
- Note: You will likely want to disable WIFI scan throttling in the Android Developer settings menu otherwise your scans will not be as frequent as possible.
+## Directions
+
+1. Press **Start scan** and move through the area of interest. **Walk a loop or
+   an L-shaped path, not a straight line** — a straight path cannot resolve how
+   far the AP is off to one side (the geometry is ambiguous), so spread your
+   samples in two dimensions.
+2. The status line shows how many APs and samples have been gathered.
+3. Press **Stop scan** when done, then **Compute & plot**.
+
+Each AP is dropped as a CoT marker tagged with its SSID/BSSID, the number of
+samples used, the estimation method, and an estimated accuracy (which is also
+written to the CoT `ce` field).
+
+> Tip: disable **Wi-Fi scan throttling** in Android Developer options, otherwise
+> Android limits you to a few scans every couple of minutes.
+
+## How the location is estimated
+
+Two estimators are used automatically (see `Trilateration.java`):
+
+- **Weighted least-squares trilateration.** Each reading is converted to a
+  *range* with a log-distance path-loss model and treated as a circle around the
+  observer's position. The maximum-likelihood intersection is solved in a local
+  east/north (metres) plane, weighting stronger (nearer) readings far more
+  heavily. Unlike a centroid, this can place the AP **off** your path.
+- **Power-weighted centroid (fallback).** Used when there are fewer than three
+  samples, or when the geometry is degenerate (e.g. a straight-line path) and the
+  least-squares solution is unstable.
+
+Accuracy depends on calibration: `Trilateration.DEFAULT_REF_RSSI_1M` (RSSI at
+1 m) and the path-loss exponents are the main tuning knobs. The maths has no
+Android dependencies and is unit-tested in `TrilaterationTest`.
+
+## Building
+
+Targets **ATAK 5.7** (`ATAK_VERSION = 5.7.0`), AGP 8.7 / Gradle 8.14, Java 17,
+`compileSdk 36`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         if(isDevKitEnabled()) {
             classpath "com.atakmap.gradle:atak-gradle-takdev:${takdevVersion}"
         } else {
@@ -144,36 +144,45 @@ android {
           abortOnError true
       }
 
+    // Signing resolves in two ways so the plugin builds both with the local
+    // devkit and on the tak.gov build service (which has no local.properties and
+    // provides a keystore at ${buildDir}/android_keystore):
+    //   1. If local.properties defines tak<Type>Key* entries, use those.
+    //   2. Otherwise fall back to the build-generated android_keystore.
     signingConfigs {
         debug {
             def kf = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takDebugKeyFile')
-            def kfp = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takDebugKeyFilePassword')
-            def ka = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takDebugKeyAlias')
-            def kp = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takDebugKeyPassword')
-
-            if (kf == null) {
-                 throw new GradleException("No signing key configured!")
+            if (kf != null) {
+                def kfp = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takDebugKeyFilePassword')
+                def ka = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takDebugKeyAlias')
+                def kp = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takDebugKeyPassword')
+                storeFile file(kf)
+                if (kfp != null) storePassword kfp
+                if (ka != null) keyAlias ka
+                if (kp != null) keyPassword kp
+            } else {
+                storeFile file("${buildDir}/android_keystore")
+                storePassword "tnttnt"
+                keyAlias "wintec_mapping"
+                keyPassword "tnttnt"
             }
- 
-            storeFile file(kf)
-            if (kfp != null) storePassword kfp
-            if (ka != null) keyAlias ka
-            if (kp != null) keyPassword kp
         }
         release {
             def kf = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takReleaseKeyFile')
-            def kfp = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takReleaseKeyFilePassword')
-            def ka = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takReleaseKeyAlias')
-            def kp = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takReleaseKeyPassword')
-
-            if (kf == null) {
-                 throw new GradleException("No signing key configured!")
+            if (kf != null) {
+                def kfp = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takReleaseKeyFilePassword')
+                def ka = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takReleaseKeyAlias')
+                def kp = getValueFromPropertiesFile(project.rootProject.file('local.properties'), 'takReleaseKeyPassword')
+                storeFile file(kf)
+                if (kfp != null) storePassword kfp
+                if (ka != null) keyAlias ka
+                if (kp != null) keyPassword kp
+            } else {
+                storeFile file("${buildDir}/android_keystore")
+                storePassword "tnttnt"
+                keyAlias "wintec_mapping"
+                keyPassword "tnttnt"
             }
-
-            storeFile file(kf)
-            if (kfp != null) storePassword kfp
-            if (ka != null) keyAlias ka
-            if (kp != null) keyPassword kp
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,6 +132,14 @@ android {
     compileSdk 36
     namespace 'com.atakmap.android.wifi2cot.plugin'
 
+    // Required by the takdev release-signing lint: the app bundle must not
+    // store an archive, otherwise it cannot be signed for release on tak.gov.
+    bundle {
+        storeArchive {
+            enable = false
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,10 +8,10 @@
 
 buildscript {
 
-    ext.PLUGIN_VERSION = "1.2"
-    ext.ATAK_VERSION = "4.10.0"
+    ext.PLUGIN_VERSION = "1.3"
+    ext.ATAK_VERSION = "5.7.0"
 
-    def takdevVersion = '2.+'
+    def takdevVersion = '3.+'
 
     ext.getValueFromPropertiesFile = { propFile, key ->
         if(!propFile.isFile() || !propFile.canRead())
@@ -59,7 +59,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         if(isDevKitEnabled()) {
             classpath "com.atakmap.gradle:atak-gradle-takdev:${takdevVersion}"
         } else {
@@ -129,19 +129,15 @@ def getVersionCode() {
 
 
 android {
-    compileSdk 33
-    buildToolsVersion "34.0.0"
-
-   dexOptions {
-        jumboMode = true
-    }
+    compileSdk 36
+    namespace 'com.atakmap.android.wifi2cot.plugin'
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
-    lintOptions {
+    lint {
           checkReleaseBuilds true
           // Or, if you prefer, you can continue to check for errors in release builds,
           // but continue the build even when errors are found:
@@ -255,7 +251,11 @@ android {
         }
 
     packagingOptions {
-        exclude 'META-INF/INDEX.LIST'
+        resources {
+            excludes += ['META-INF/INDEX.LIST']
+        }
+        // Plugins must ship uncompressed native libs so ATAK can load them.
+        jniLibs.useLegacyPackaging true
     }
 
     sourceSets {
@@ -284,8 +284,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 24
-        targetSdkVersion 33
+        minSdkVersion 26
+        targetSdkVersion 34
         ndk {
             abiFilters "armeabi-v7a", "arm64-v8a", "x86"
         }
@@ -295,5 +295,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
+
+    testImplementation 'junit:junit:4.13.2'
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.atakmap.android.wifi2cot.plugin"
     tools:ignore="GoogleAppIndexingWarning">
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,6 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:description="@string/app_desc"
-        android:extractNativeLibs="true"
         android:theme="@style/AppTheme" >
         <meta-data android:name="plugin-api" android:value="${atakApiVersion}"/>
         <meta-data android:name="app_desc" android:value="@string/app_desc"/>

--- a/app/src/main/java/com/atakmap/android/wifi2cot/Sample.java
+++ b/app/src/main/java/com/atakmap/android/wifi2cot/Sample.java
@@ -1,0 +1,41 @@
+
+package com.atakmap.android.wifi2cot;
+
+/**
+ * A single Wi-Fi observation: the signal seen from an access point together
+ * with the observer's own position at the moment of the reading.
+ *
+ * <p>RSSI is stored as the <em>raw</em> value in dBm (a negative number such as
+ * -55). The old code stored {@code 100 - abs(rssi)}, which threw away the sign
+ * and linearised a logarithmic quantity; keeping the raw dBm lets the estimator
+ * convert to range (path-loss) and to linear power (weighting) correctly.
+ */
+public final class Sample {
+
+    /** Raw received signal strength, dBm (negative; closer to 0 is stronger). */
+    public final int rssi;
+    /** Channel centre frequency, MHz (used to pick the path-loss exponent). */
+    public final int freq;
+    /** Observer latitude at the time of the reading, decimal degrees. */
+    public final double lat;
+    /** Observer longitude at the time of the reading, decimal degrees. */
+    public final double lng;
+    /** Observer altitude, metres HAE, or {@link Double#NaN} if unknown. */
+    public final double alt;
+    public final String bssid;
+    public final String ssid;
+    /** Epoch milliseconds when the reading was taken. */
+    public final long time;
+
+    public Sample(int rssi, int freq, double lat, double lng, double alt,
+                  String bssid, String ssid, long time) {
+        this.rssi = rssi;
+        this.freq = freq;
+        this.lat = lat;
+        this.lng = lng;
+        this.alt = alt;
+        this.bssid = bssid;
+        this.ssid = ssid;
+        this.time = time;
+    }
+}

--- a/app/src/main/java/com/atakmap/android/wifi2cot/Trilateration.java
+++ b/app/src/main/java/com/atakmap/android/wifi2cot/Trilateration.java
@@ -1,0 +1,230 @@
+
+package com.atakmap.android.wifi2cot;
+
+import java.util.List;
+
+/**
+ * Estimates the position of a Wi-Fi access point from a set of
+ * {@link Sample} observations (RSSI + the observer's position).
+ *
+ * <p>Two estimators are provided and selected automatically:
+ *
+ * <ol>
+ *   <li><b>Weighted least-squares trilateration.</b> Each observation is turned
+ *       into a <em>range</em> via a log-distance path-loss model and treated as
+ *       a circle centred on the observer. The maximum-likelihood intersection of
+ *       those circles is solved in a local ENU (east/north, metres) tangent
+ *       plane. Crucially this can place the AP <em>off</em> the observer's path
+ *       &mdash; something a centroid can never do.</li>
+ *   <li><b>Power-weighted centroid (fallback).</b> Used when there are fewer
+ *       than three samples, or when the geometry is degenerate (e.g. all samples
+ *       lie on a line, so the perpendicular offset is unobservable) and the
+ *       least-squares normal matrix is singular.</li>
+ * </ol>
+ *
+ * <p>The class is deliberately free of any Android/ATAK dependency so the maths
+ * can be unit-tested on a plain JVM (see {@code TrilaterationTest}).
+ */
+public final class Trilateration {
+
+    /**
+     * RSSI (dBm) expected at 1 m from a typical consumer AP. This is the single
+     * biggest knob on absolute range accuracy; -40 dBm is a reasonable default
+     * for 2.4 GHz consumer gear. Exposed so callers can calibrate.
+     */
+    public static final double DEFAULT_REF_RSSI_1M = -40.0;
+
+    /** Path-loss exponent for 2.4 GHz (free space 2.0; light indoor 2.2-2.7). */
+    public static final double PATH_LOSS_2G = 2.2;
+    /** Path-loss exponent for 5 GHz (shorter wavelength attenuates faster). */
+    public static final double PATH_LOSS_5G = 2.5;
+
+    /** Metres per degree of latitude (WGS-84 mean; good to ~0.3% anywhere). */
+    private static final double M_PER_DEG_LAT = 111_320.0;
+    private static final double EPS = 1e-9;
+    /** Reject solutions further than this (m) from the samples as nonsense. */
+    private static final double MAX_PLAUSIBLE_M = 100_000.0;
+
+    /** Result of an estimate. Immutable. */
+    public static final class Estimate {
+        public final double lat;
+        public final double lng;
+        /** Approximate 1-sigma circular error, metres (feeds the CoT {@code ce}). */
+        public final double ce;
+        public final int sampleCount;
+        /** {@code "trilateration"} or {@code "centroid"}. */
+        public final String method;
+
+        Estimate(double lat, double lng, double ce, int sampleCount, String method) {
+            this.lat = lat;
+            this.lng = lng;
+            this.ce = ce;
+            this.sampleCount = sampleCount;
+            this.method = method;
+        }
+    }
+
+    private Trilateration() {
+    }
+
+    /**
+     * Log-distance path-loss range, metres, for one reading:
+     * {@code d = 10 ^ ((P@1m - RSSI) / (10 * n))}.
+     */
+    public static double rssiToDistance(int rssiDbm, int freqMhz, double refRssi1m) {
+        double n = (freqMhz > 5000) ? PATH_LOSS_5G : PATH_LOSS_2G;
+        return Math.pow(10.0, (refRssi1m - rssiDbm) / (10.0 * n));
+    }
+
+    public static Estimate estimate(List<Sample> samples) {
+        return estimate(samples, DEFAULT_REF_RSSI_1M);
+    }
+
+    /**
+     * @param samples   observations for a single BSSID
+     * @param refRssi1m calibrated RSSI at 1 m (see {@link #DEFAULT_REF_RSSI_1M})
+     * @return best estimate, or {@code null} if {@code samples} is empty
+     */
+    public static Estimate estimate(List<Sample> samples, double refRssi1m) {
+        if (samples == null || samples.isEmpty())
+            return null;
+
+        final int n = samples.size();
+
+        // Local tangent-plane origin = mean of the observation points. Working in
+        // metres (not raw lat/lng degrees) keeps east/north on the same scale.
+        double lat0 = 0, lng0 = 0;
+        for (Sample s : samples) {
+            lat0 += s.lat;
+            lng0 += s.lng;
+        }
+        lat0 /= n;
+        lng0 /= n;
+        final double mPerDegLng = M_PER_DEG_LAT * Math.cos(Math.toRadians(lat0));
+
+        double[] x = new double[n];
+        double[] y = new double[n];
+        double[] r = new double[n];
+        double[] w = new double[n];
+        for (int i = 0; i < n; i++) {
+            Sample s = samples.get(i);
+            x[i] = (s.lng - lng0) * mPerDegLng;
+            y[i] = (s.lat - lat0) * M_PER_DEG_LAT;
+            r[i] = rssiToDistance(s.rssi, s.freq, refRssi1m);
+            // Reliability weight = linear received power (dBm -> mW). A -50 dBm
+            // sample outweighs a -90 dBm one by ~10^4, so strong/near readings
+            // dominate, as they should. Only ratios matter, so the unit cancels.
+            w[i] = Math.pow(10.0, s.rssi / 10.0);
+        }
+
+        Estimate tri = solveLeastSquares(x, y, r, w, n, lat0, lng0, mPerDegLng);
+        if (tri != null)
+            return tri;
+        return centroid(x, y, r, w, n, lat0, lng0, mPerDegLng);
+    }
+
+    /**
+     * Weighted linear least-squares circle intersection.
+     *
+     * <p>Each circle {@code (x-xi)^2 + (y-yi)^2 = ri^2} is differenced against a
+     * reference circle {@code k} to cancel the quadratic terms, giving a linear
+     * system {@code A p = b} with
+     * {@code A_i = [2(xi-xk), 2(yi-yk)]} and
+     * {@code b_i = (xi^2+yi^2-ri^2) - (xk^2+yk^2-rk^2)}.
+     * It is solved via the weighted 2x2 normal equations.
+     *
+     * @return the estimate, or {@code null} if under-determined / degenerate.
+     */
+    private static Estimate solveLeastSquares(double[] x, double[] y, double[] r,
+            double[] w, int n, double lat0, double lng0, double mPerDegLng) {
+        if (n < 3)
+            return null;
+
+        // Reference = strongest signal (max weight) -> smallest, most reliable range.
+        int k = 0;
+        for (int i = 1; i < n; i++)
+            if (w[i] > w[k])
+                k = i;
+        final double dk = x[k] * x[k] + y[k] * y[k] - r[k] * r[k];
+
+        double saa = 0, sab = 0, sbb = 0, sa = 0, sb = 0;
+        for (int i = 0; i < n; i++) {
+            if (i == k)
+                continue;
+            double a1 = 2.0 * (x[i] - x[k]);
+            double a2 = 2.0 * (y[i] - y[k]);
+            double di = x[i] * x[i] + y[i] * y[i] - r[i] * r[i];
+            double b = di - dk;
+            // Pair reliability: a differenced equation is only as good as its
+            // weaker member, so weight by the smaller of the two powers.
+            double wi = Math.min(w[i], w[k]);
+            saa += wi * a1 * a1;
+            sab += wi * a1 * a2;
+            sbb += wi * a2 * a2;
+            sa += wi * a1 * b;
+            sb += wi * a2 * b;
+        }
+
+        double det = saa * sbb - sab * sab;
+        double scale = saa + sbb;
+        // Scale-aware singularity test: collinear samples leave the perpendicular
+        // direction unobservable, making the matrix rank-deficient -> fall back.
+        if (scale < EPS || Math.abs(det) < EPS * scale * scale)
+            return null;
+
+        double ex = (sbb * sa - sab * sb) / det;
+        double ey = (saa * sb - sab * sa) / det;
+
+        // Circular error from the weighted RMS range residual.
+        double sw = 0, sres = 0;
+        for (int i = 0; i < n; i++) {
+            double dx = ex - x[i];
+            double dy = ey - y[i];
+            double residual = Math.sqrt(dx * dx + dy * dy) - r[i];
+            sres += w[i] * residual * residual;
+            sw += w[i];
+        }
+        double ce = (sw > 0) ? Math.sqrt(sres / sw) : Double.NaN;
+
+        double lat = lat0 + ey / M_PER_DEG_LAT;
+        double lng = lng0 + ex / mPerDegLng;
+
+        if (Double.isNaN(lat) || Double.isNaN(lng) || Double.isNaN(ce)
+                || Math.hypot(ex, ey) > MAX_PLAUSIBLE_M)
+            return null; // numerically blew up -> let the centroid handle it
+
+        return new Estimate(lat, lng, ce, n, "trilateration");
+    }
+
+    /** Power-weighted centroid of the observation points (fallback estimator). */
+    private static Estimate centroid(double[] x, double[] y, double[] r,
+            double[] w, int n, double lat0, double lng0, double mPerDegLng) {
+        double sw = 0, sx = 0, sy = 0;
+        for (int i = 0; i < n; i++) {
+            sw += w[i];
+            sx += w[i] * x[i];
+            sy += w[i] * y[i];
+        }
+        if (sw <= 0)
+            return null;
+        double ex = sx / sw;
+        double ey = sy / sw;
+
+        // A centroid is pinned to (inside) the sample path, so its real
+        // uncertainty is large: the spread of the samples PLUS how far off-path
+        // the AP could be, floored by the closest (strongest) estimated range.
+        double svar = 0, minRange = Double.MAX_VALUE;
+        for (int i = 0; i < n; i++) {
+            double dx = ex - x[i];
+            double dy = ey - y[i];
+            svar += w[i] * (dx * dx + dy * dy);
+            minRange = Math.min(minRange, r[i]);
+        }
+        double spread = Math.sqrt(svar / sw);
+        double ce = spread + (minRange == Double.MAX_VALUE ? 0 : minRange);
+
+        double lat = lat0 + ey / M_PER_DEG_LAT;
+        double lng = lng0 + ex / mPerDegLng;
+        return new Estimate(lat, lng, ce, n, "centroid");
+    }
+}

--- a/app/src/main/java/com/atakmap/android/wifi2cot/wifi2cotDropDownReceiver.java
+++ b/app/src/main/java/com/atakmap/android/wifi2cot/wifi2cotDropDownReceiver.java
@@ -5,13 +5,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.view.View;
 import android.widget.Button;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.atakmap.android.cot.CotMapComponent;
 import com.atakmap.coremap.cot.event.CotDetail;
 import com.atakmap.coremap.cot.event.CotEvent;
 import com.atakmap.coremap.cot.event.CotPoint;
-
 
 import com.atak.plugins.impl.PluginLayoutInflater;
 import com.atakmap.android.maps.MapView;
@@ -22,13 +22,11 @@ import com.atakmap.android.dropdown.DropDownReceiver;
 import com.atakmap.coremap.log.Log;
 import com.atakmap.coremap.maps.time.CoordinatedTime;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
-
 
 public class wifi2cotDropDownReceiver extends DropDownReceiver implements
         OnStateListener {
@@ -36,16 +34,19 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
     public static final String TAG = "wifi2cotDropDownReceiver";
 
     public static final String SHOW_PLUGIN = "com.atakmap.android.wifi2cot.SHOW_PLUGIN";
+
+    /** Wi-Fi APs are re-scanned on this cadence while a scan is running. */
+    private static final long SCAN_PERIOD_MS = 5000L;
+
     private final View templateView;
     private final Context pluginContext;
-
     private final wifi2cotMapComponent mc;
 
     private final Button start, stop, guess;
+    private final TextView status;
 
     private Timer timer;
-
-    private boolean scanning = false;
+    private volatile boolean scanning = false;
 
     /**************************** CONSTRUCTOR *****************************/
 
@@ -55,20 +56,20 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
         this.pluginContext = context;
         this.mc = mc;
 
-        // Remember to use the PluginLayoutInflator if you are actually inflating a custom view
-        // In this case, using it is not necessary - but I am putting it here to remind
-        // developers to look at this Inflator
-        templateView = PluginLayoutInflater.inflate(context,
-                R.layout.main_layout, null);
+        templateView = PluginLayoutInflater.inflate(context, R.layout.main_layout, null);
 
         start = templateView.findViewById(R.id.start);
         stop = templateView.findViewById(R.id.stop);
         guess = templateView.findViewById(R.id.guess);
+        status = templateView.findViewById(R.id.status);
+
+        setControlsForIdle();
     }
 
     /**************************** PUBLIC METHODS *****************************/
 
     public void disposeImpl() {
+        stopScanning();
     }
 
     /**************************** INHERITED METHODS *****************************/
@@ -81,42 +82,168 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
             return;
 
         if (action.equals(SHOW_PLUGIN)) {
-
             Log.d(TAG, "showing plugin drop down");
             showDropDown(templateView, HALF_WIDTH, FULL_HEIGHT, FULL_WIDTH,
                     HALF_HEIGHT, false, this);
 
-            start.setOnClickListener(view -> {
-                Log.d(TAG, "Starting scan");
-                scanning = true;
-                Toast.makeText(MapView._mapView.getContext(), "Starting scan",
-                        Toast.LENGTH_LONG).show();
-                wifi2cotMapComponent.getNodes().clear();
-                timer = new Timer();
-                timer.schedule(new TimerTask() {
-                    @Override
-                    public void run() {
-                        if (!mc.getWifiManager().startScan()) {
-                            Log.d(TAG, "Scan failed");
-                        }
-                    }
-                },0, 5000);
-            });
+            start.setOnClickListener(view -> startScanning());
+            stop.setOnClickListener(view -> stopScanning());
+            guess.setOnClickListener(view -> compute());
 
-            stop.setOnClickListener(view -> {
-                scanning = false;
-                timer.cancel();
-                Log.d(TAG, "Stopping scan");
-                Toast.makeText(MapView._mapView.getContext(), "Stopping scan",
-                        Toast.LENGTH_LONG).show();
-            });
-
-            guess.setOnClickListener(view -> {
-                Toast.makeText(MapView._mapView.getContext(), "Computing results",
-                        Toast.LENGTH_LONG).show();
-                compute();
-            });
+            updateStatus();
         }
+    }
+
+    /**************************** SCANNING *****************************/
+
+    private void startScanning() {
+        if (scanning)
+            return;
+        Log.d(TAG, "Starting scan");
+        wifi2cotMapComponent.clearNodes();
+        scanning = true;
+        setControlsForScanning();
+        toast("Scanning started — walk the area to gather signal");
+
+        timer = new Timer();
+        timer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                if (mc.getWifiManager() != null && !mc.getWifiManager().startScan())
+                    Log.d(TAG, "startScan() returned false (likely throttled)");
+                status.post(() -> updateStatus());
+            }
+        }, 0, SCAN_PERIOD_MS);
+    }
+
+    private void stopScanning() {
+        if (!scanning && timer == null)
+            return;
+        Log.d(TAG, "Stopping scan");
+        scanning = false;
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+        }
+        setControlsForIdle();
+        updateStatus();
+        toast("Scanning stopped");
+    }
+
+    /**************************** ESTIMATION *****************************/
+
+    /** Estimate each AP's position from its samples and push a CoT marker. */
+    public void compute() {
+        Log.d(TAG, "In compute");
+
+        final Map<String, List<Sample>> nodes = wifi2cotMapComponent.getNodes();
+        if (nodes.isEmpty()) {
+            toast("No access points captured yet — start a scan first");
+            return;
+        }
+
+        int emitted = 0;
+        for (Map.Entry<String, List<Sample>> entry : nodes.entrySet()) {
+            final List<Sample> samples = entry.getValue();
+            if (samples == null || samples.isEmpty())
+                continue;
+
+            Trilateration.Estimate est = Trilateration.estimate(samples);
+            if (est == null)
+                continue;
+
+            Sample meta = samples.get(0);
+            String bssid = meta.bssid;
+            String ssid = (meta.ssid == null || meta.ssid.isEmpty()) ? bssid : meta.ssid;
+
+            if (dispatch(est, bssid, ssid))
+                emitted++;
+        }
+
+        Log.d(TAG, "Plotted " + emitted + " access points");
+        toast("Plotted " + emitted + " access point(s)");
+        updateStatus();
+    }
+
+    private boolean dispatch(Trilateration.Estimate est, String bssid, String ssid) {
+        CotEvent cotEvent = new CotEvent();
+
+        CoordinatedTime time = new CoordinatedTime();
+        cotEvent.setTime(time);
+        cotEvent.setStart(time);
+        cotEvent.setStale(time.addMinutes(90));
+
+        // Stable, namespaced UID so re-running compute() updates the same marker
+        // instead of spawning duplicates.
+        cotEvent.setUID("wifi2cot." + bssid);
+        cotEvent.setType("a-u-G"); // atom, unknown affiliation, ground
+        cotEvent.setHow("m-g");
+
+        double ce = Double.isNaN(est.ce) ? CotPoint.UNKNOWN : Math.max(1.0, est.ce);
+        CotPoint cotPoint = new CotPoint(est.lat, est.lng, CotPoint.UNKNOWN, ce,
+                CotPoint.UNKNOWN);
+        cotEvent.setPoint(cotPoint);
+
+        CotDetail detail = new CotDetail("detail");
+        cotEvent.setDetail(detail);
+
+        CotDetail contact = new CotDetail("contact");
+        contact.setAttribute("callsign", ssid);
+        detail.addChild(contact);
+
+        // Tell ATAK this position is calculated, not a real GPS fix.
+        CotDetail precision = new CotDetail("precisionlocation");
+        precision.setAttribute("geopointsrc", "CALC");
+        precision.setAttribute("altsrc", "???");
+        detail.addChild(precision);
+
+        CotDetail remarks = new CotDetail("remarks");
+        remarks.setAttribute("source", "wifi2cot");
+        remarks.setInnerText(String.format(Locale.US,
+                "SSID: %s\nBSSID: %s\nSamples: %d\nMethod: %s\nEst. accuracy: %s",
+                ssid, bssid, est.sampleCount, est.method,
+                Double.isNaN(est.ce) ? "unknown"
+                        : String.format(Locale.US, "%.0f m", est.ce)));
+        detail.addChild(remarks);
+
+        if (cotEvent.isValid()) {
+            CotMapComponent.getInternalDispatcher().dispatch(cotEvent);
+            return true;
+        }
+        Log.e(TAG, "cotEvent was not valid for " + bssid);
+        return false;
+    }
+
+    /**************************** UI HELPERS *****************************/
+
+    private void updateStatus() {
+        if (status == null)
+            return;
+        int aps = wifi2cotMapComponent.getNodes().size();
+        int samples = wifi2cotMapComponent.totalSamples();
+        String text = scanning
+                ? String.format(Locale.US, "Scanning…  %d APs · %d samples", aps, samples)
+                : (aps == 0 ? "Idle — press Start to scan"
+                        : String.format(Locale.US, "Ready — %d APs · %d samples", aps, samples));
+        status.setText(text);
+    }
+
+    private void setControlsForScanning() {
+        start.setEnabled(false);
+        stop.setEnabled(true);
+        guess.setEnabled(true);
+        updateStatus();
+    }
+
+    private void setControlsForIdle() {
+        start.setEnabled(true);
+        stop.setEnabled(false);
+        guess.setEnabled(true);
+        updateStatus();
+    }
+
+    private void toast(String msg) {
+        Toast.makeText(getMapView().getContext(), msg, Toast.LENGTH_SHORT).show();
     }
 
     @Override
@@ -133,97 +260,6 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
 
     @Override
     public void onDropDownClose() {
-    }
-
-    public void compute() {
-
-        Log.d(TAG, "In compute");
-
-        HashMap<String, List<String[]>> nodes = wifi2cotMapComponent.getNodes();
-
-        double[] rssi_sum = new double[nodes.size()];
-        double[] SignalRatio_LatLng = new double[nodes.size()];
-
-        // build rssi_sum
-        // for every BSSID, sum up all the rssi values rssi value = 100 - abs(rssi)
-        int i = 0;
-        for (Map.Entry<String, List<String[]>> s: nodes.entrySet()) {
-            Log.d(TAG, s.getKey());
-            for (String[] l: s.getValue()) {
-                rssi_sum[i] += Integer.parseInt(l[0]);
-                Log.d(TAG, String.format(Locale.US, "RECORD: %s %s %s", l[0],l[1],l[2]));
-            }
-            Log.d(TAG, String.format(Locale.US, "RSSI_SUM %f", rssi_sum[i]));
-            i++;
-        }
-
-        // build signal ratio
-        // for every rssi value, divided by the rssi_sum for that point for a SR
-        i = 0;
-        for (Map.Entry<String, List<String[]>> s: nodes.entrySet()) {
-            for (String[] l: s.getValue()) {
-                SignalRatio_LatLng[i] = Integer.parseInt(l[0]) / rssi_sum[i];
-                Log.d(TAG, String.format(Locale.US, "SR: %f", SignalRatio_LatLng[i]));
-            }
-            i++;
-        }
-
-        // approx triangulation
-        // sum up all the lat/lng * SR for that point
-        i = 0;
-        for (Map.Entry<String, List<String[]>> s: nodes.entrySet()) {
-            double lat = 0.0;
-            double lng = 0.0;
-            String bssid = "";
-            String ssid = "";
-            int sampleSize = 0;
-
-            for (String[] l: s.getValue()) {
-                lat += (Double.parseDouble(l[1]) * SignalRatio_LatLng[i]);
-                lng += (Double.parseDouble(l[2]) * SignalRatio_LatLng[i]);
-                bssid = l[3];
-                ssid = l[4];
-                sampleSize++;
-            }
-            Log.d(TAG, String.format(Locale.US, "LAT: %.14f LNG: %.14f", lat, lng));
-            i++;
-
-            CotEvent cotEvent = new CotEvent();
-
-            CoordinatedTime time = new CoordinatedTime();
-            cotEvent.setTime(time);
-            cotEvent.setStart(time);
-            cotEvent.setStale(time.addMinutes(90));
-
-            cotEvent.setUID(bssid);
-
-            cotEvent.setType("a-f-G-I-E");
-
-            cotEvent.setHow("m-g");
-
-            CotPoint cotPoint = new CotPoint(lat, lng, CotPoint.UNKNOWN,
-                    CotPoint.UNKNOWN, CotPoint.UNKNOWN);
-            cotEvent.setPoint(cotPoint);
-
-            CotDetail cotDetail = new CotDetail("detail");
-            cotEvent.setDetail(cotDetail);
-
-            CotDetail contactDetail = new CotDetail("contact");
-            contactDetail.setAttribute("callsign", ssid);
-            contactDetail.setAttribute("endpoint", "0.0.0.0:4242:tcp");
-
-            CotDetail cotRemark = new CotDetail("remarks");
-            cotRemark.setAttribute("source", "wifi2cot");
-            cotRemark.setInnerText(String.format(Locale.US, "SSID: %s\nSample size: %d", ssid, sampleSize));
-
-            cotDetail.addChild(contactDetail);
-            cotDetail.addChild(cotRemark);
-
-            if (cotEvent.isValid())
-                CotMapComponent.getInternalDispatcher().dispatch(cotEvent);
-            else
-                Log.e(TAG, "cotEvent was not valid");
-        }
     }
 
     public boolean isScanning() {

--- a/app/src/main/java/com/atakmap/android/wifi2cot/wifi2cotMapComponent.java
+++ b/app/src/main/java/com/atakmap/android/wifi2cot/wifi2cotMapComponent.java
@@ -11,50 +11,57 @@ import android.net.wifi.WifiManager;
 import com.atakmap.android.ipc.AtakBroadcast.DocumentedIntentFilter;
 
 import com.atakmap.android.maps.MapView;
+import com.atakmap.android.maps.Marker;
 import com.atakmap.android.dropdown.DropDownMapComponent;
+import com.atakmap.coremap.maps.coords.GeoPoint;
 
 import com.atakmap.coremap.log.Log;
 import com.atakmap.android.wifi2cot.plugin.R;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class wifi2cotMapComponent extends DropDownMapComponent {
 
     private static final String TAG = "wifi2cotMapComponent";
-
-    private Context pluginContext;
 
     private MapView mapView;
 
     private wifi2cotDropDownReceiver ddr;
 
     private WifiManager wifiManager;
+    private BroadcastReceiver wifiScanReceiver;
 
-    // nodes will hold k,v for the BSSID and the rssi,lat,lng,bssid,ssid values
-    private final static HashMap<String, List<String[]>> nodes = new HashMap<>();
+    // Single worker so scan callbacks are processed in order off the UI thread
+    // (the old code spawned a fresh Thread per callback -> races on `nodes`).
+    private final ExecutorService worker = Executors.newSingleThreadExecutor();
+
+    // BSSID -> observations. Concurrent map + copy-on-write lists so the worker
+    // thread can append while the UI thread reads in compute() without locking.
+    private static final Map<String, List<Sample>> nodes = new ConcurrentHashMap<>();
 
     public void onCreate(final Context context, Intent intent,
             final MapView view) {
 
         context.setTheme(R.style.ATAKPluginTheme);
         super.onCreate(context, intent, view);
-        pluginContext = context;
         mapView = view;
 
-        ddr = new wifi2cotDropDownReceiver(
-                view, context, this);
+        ddr = new wifi2cotDropDownReceiver(view, context, this);
 
         Log.d(TAG, "registering the plugin filter");
         DocumentedIntentFilter ddFilter = new DocumentedIntentFilter();
         ddFilter.addAction(wifi2cotDropDownReceiver.SHOW_PLUGIN);
         registerDropDownReceiver(ddr, ddFilter);
 
-        wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+        wifiManager = (WifiManager) context.getApplicationContext()
+                .getSystemService(Context.WIFI_SERVICE);
 
-        BroadcastReceiver wifiScanReceiver = new BroadcastReceiver() {
+        wifiScanReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context c, Intent intent) {
                 boolean success = intent.getBooleanExtra(
@@ -63,7 +70,6 @@ public class wifi2cotMapComponent extends DropDownMapComponent {
                 if (success) {
                     scanSuccess();
                 } else {
-                    // scan failure handling
                     scanFailure();
                 }
             }
@@ -71,106 +77,70 @@ public class wifi2cotMapComponent extends DropDownMapComponent {
 
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION);
-        context.registerReceiver(wifiScanReceiver, intentFilter);
-
-        boolean success = wifiManager.startScan();
-        if (!success) {
-            // scan failure handling
-            scanFailure();
-        }
-    }
-
-    double getDistance(int rssi, int txPower, int freq) {
-        /*
-         * RSSI = TxPower - 10 * n * lg(d)
-         * n = 2 (in free space)
-         *
-         * d = 10 ^ ((TxPower - RSSI) / (10 * n))
-         */
-        int n = 2;
-        if (freq > 5000) {
-            n++;
-        }
-        return Math.pow(10d, ((double) txPower - rssi) / (10 * n));
+        context.getApplicationContext().registerReceiver(wifiScanReceiver, intentFilter);
     }
 
     private void scanSuccess() {
-
-        Log.d(TAG, "Inside scanSuccess");
 
         if (!ddr.isScanning()) {
             Log.d(TAG, "Not in scanning mode");
             return;
         }
+        if (wifiManager == null)
+            return;
 
-        new Thread() {
-            @Override
-            public void run() {
+        // Snapshot the observer position ONCE per scan batch (it is constant for
+        // the batch) and bail early if we have no fix.
+        Marker self = mapView.getSelfMarker();
+        GeoPoint here = (self != null) ? self.getPoint() : null;
+        if (here == null || !here.isValid()
+                || (Math.abs(here.getLatitude()) < 1e-9
+                        && Math.abs(here.getLongitude()) < 1e-9)) {
+            Log.d(TAG, "No GPS fix; dropping scan batch");
+            return;
+        }
 
-                List<ScanResult> results = wifiManager.getScanResults();
-                for (ScanResult s: results) {
+        final double lat = here.getLatitude();
+        final double lng = here.getLongitude();
+        final double alt = here.isAltitudeValid()
+                ? here.getAltitude() : Double.NaN;
+        final long now = System.currentTimeMillis();
 
-                    Log.d(TAG, "Scan result: BSSID: " + s.BSSID + " SSID: " + s.SSID + " RSSI: " + s.level + " Freq: " + s.frequency);
+        final List<ScanResult> results = wifiManager.getScanResults();
 
-                    double lat = mapView.getSelfMarker().getPoint().getLatitude();
-                    double lng = mapView.getSelfMarker().getPoint().getLongitude();
+        worker.execute(() -> {
+            for (ScanResult s : results) {
+                if (s.BSSID == null)
+                    continue; // skip malformed result, keep processing the rest
 
-                    if (lat == 0 && lng == 0) {
-                        Log.d(TAG, "No GPS fix");
-                        return;
-                    }
+                Log.d(TAG, "Scan result: BSSID: " + s.BSSID + " SSID: " + s.SSID
+                        + " RSSI: " + s.level + " Freq: " + s.frequency);
 
-                    // data will be String["rssi", "self.lat", "self.lng", "bssid", "ssid"]
-                    if (!nodes.containsKey(s.BSSID)) {
-                        ArrayList<String[]> data = new ArrayList<>();
-                        String[] sample = new String[5];
-                        sample[0] = String.valueOf(100 - Math.abs(s.level));
-                        sample[1] = String.valueOf(lat);
-                        sample[2] = String.valueOf(lng);
-                        sample[3] = s.BSSID;
-                        sample[4] = s.SSID;
+                Sample sample = new Sample(s.level, s.frequency, lat, lng, alt,
+                        s.BSSID, s.SSID == null ? "" : s.SSID, now);
 
-                        if (sample[1].startsWith("0.0") && sample[2].startsWith("0.0")) {
-                            return;
-                        }
-
-                        data.add(sample);
-                        nodes.put(s.BSSID, data);
-                    } else {
-                        List<String[]> data = nodes.get(s.BSSID);
-                        String[] sample = new String[5];
-                        sample[0] = String.valueOf(100 - Math.abs(s.level));
-                        sample[1] = String.valueOf(lat);
-                        sample[2] = String.valueOf(lng);
-                        sample[3] = s.BSSID;
-                        sample[4] = s.SSID;
-
-                        if (sample[1].startsWith("0.0") && sample[2].startsWith("0.0")) {
-                            return;
-                        }
-
-                        try {
-                            data.add(sample);
-                            nodes.put(s.BSSID, data);
-                        } catch (NullPointerException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                }
+                // computeIfAbsent + COW list = safe concurrent append.
+                nodes.computeIfAbsent(s.BSSID,
+                        k -> new CopyOnWriteArrayList<>()).add(sample);
             }
-        }.start();
+        });
     }
 
     private void scanFailure() {
-        // handle failure: new scan did NOT succeed
-        // consider using old scan results: these are the OLD results!
-        List<ScanResult> results = wifiManager.getScanResults();
-        Log.d(TAG, "Scan failed");
-//  ... potentially use older scan results ...
+        // A failed scan just means the OS returned cached results; do not ingest
+        // them (their position would be wrong) and do not spam errors.
+        Log.d(TAG, "Scan failed (throttled or no new results)");
     }
 
     @Override
     protected void onDestroyImpl(Context context, MapView view) {
+        try {
+            if (wifiScanReceiver != null)
+                context.getApplicationContext().unregisterReceiver(wifiScanReceiver);
+        } catch (IllegalArgumentException e) {
+            Log.w(TAG, "scan receiver already unregistered", e);
+        }
+        worker.shutdownNow();
         super.onDestroyImpl(context, view);
     }
 
@@ -178,8 +148,20 @@ public class wifi2cotMapComponent extends DropDownMapComponent {
         return this.wifiManager;
     }
 
-    public static HashMap<String, List<String[]>> getNodes() {
+    public static Map<String, List<Sample>> getNodes() {
         return nodes;
     }
 
+    /** Total readings captured across all access points (for the UI status). */
+    public static int totalSamples() {
+        int total = 0;
+        for (List<Sample> v : nodes.values())
+            total += v.size();
+        return total;
+    }
+
+    /** Wrapper so callers don't fight {@code Map} immutability semantics. */
+    public static void clearNodes() {
+        nodes.clear();
+    }
 }

--- a/app/src/main/res/color/w2c_text_on_dark.xml
+++ b/app/src/main/res/color/w2c_text_on_dark.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/w2c_disabled_text" />
+    <item android:color="@color/w2c_text_primary" />
+</selector>

--- a/app/src/main/res/color/w2c_text_on_primary.xml
+++ b/app/src/main/res/color/w2c_text_on_primary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/w2c_disabled_text" />
+    <item android:color="#06231C" />
+</selector>

--- a/app/src/main/res/drawable/w2c_btn_danger.xml
+++ b/app/src/main/res/drawable/w2c_btn_danger.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="@color/w2c_disabled" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="@color/w2c_danger_pressed" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <stroke android:width="1dp" android:color="@color/w2c_danger" />
+            <solid android:color="#1E1416" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/w2c_btn_neutral.xml
+++ b/app/src/main/res/drawable/w2c_btn_neutral.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="@color/w2c_disabled" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="@color/w2c_neutral_pressed" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <stroke android:width="1dp" android:color="@color/w2c_stroke" />
+            <solid android:color="@color/w2c_neutral" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/w2c_btn_primary.xml
+++ b/app/src/main/res/drawable/w2c_btn_primary.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="@color/w2c_disabled" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="@color/w2c_accent_pressed" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="@color/w2c_accent" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/w2c_card.xml
+++ b/app/src/main/res/drawable/w2c_card.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="18dp" />
+    <gradient
+        android:angle="90"
+        android:startColor="#121519"
+        android:endColor="#1B1F24" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/w2c_stroke" />
+</shape>

--- a/app/src/main/res/drawable/w2c_status_pill.xml
+++ b/app/src/main/res/drawable/w2c_status_pill.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="10dp" />
+    <solid android:color="@color/w2c_accent_soft" />
+    <stroke
+        android:width="1dp"
+        android:color="#1B4A3E" />
+</shape>

--- a/app/src/main/res/layout/main_layout.xml
+++ b/app/src/main/res/layout/main_layout.xml
@@ -1,45 +1,129 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:fadeScrollbars="false"
-    android:layout_marginLeft="3dp"
-    android:layout_marginRight="3dp">
+    android:fillViewport="true"
+    android:padding="10dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical" >
+        android:orientation="vertical"
+        android:background="@drawable/w2c_card"
+        android:padding="18dp">
 
+        <!-- Header -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <View
+                android:layout_width="4dp"
+                android:layout_height="34dp"
+                android:background="@color/w2c_accent" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="12dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/w2c_title"
+                    android:textColor="@color/w2c_text_primary"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    android:letterSpacing="0.12" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/w2c_subtitle"
+                    android:textColor="@color/w2c_text_secondary"
+                    android:textSize="12sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <!-- Divider -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:background="@color/w2c_stroke" />
+
+        <!-- Status pill -->
         <TextView
-            android:layout_width="wrap_content"
+            android:id="@+id/status"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/app_name" />
+            android:background="@drawable/w2c_status_pill"
+            android:paddingLeft="14dp"
+            android:paddingRight="14dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:text="@string/w2c_status_idle"
+            android:textColor="@color/w2c_accent"
+            android:textSize="14sp"
+            android:fontFamily="monospace" />
 
+        <!-- Primary action -->
+        <Button
+            android:id="@+id/start"
+            android:layout_width="match_parent"
+            android:layout_height="52dp"
+            android:layout_marginTop="18dp"
+            android:background="@drawable/w2c_btn_primary"
+            android:text="@string/w2c_start"
+            android:textColor="@color/w2c_text_on_primary"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            android:textAllCaps="false"
+            android:stateListAnimator="@null" />
+
+        <!-- Stop -->
+        <Button
+            android:id="@+id/stop"
+            android:layout_width="match_parent"
+            android:layout_height="52dp"
+            android:layout_marginTop="10dp"
+            android:background="@drawable/w2c_btn_danger"
+            android:text="@string/w2c_stop"
+            android:textColor="@color/w2c_text_on_dark"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            android:textAllCaps="false"
+            android:stateListAnimator="@null" />
+
+        <!-- Compute -->
+        <Button
+            android:id="@+id/guess"
+            android:layout_width="match_parent"
+            android:layout_height="52dp"
+            android:layout_marginTop="10dp"
+            android:background="@drawable/w2c_btn_neutral"
+            android:text="@string/w2c_compute"
+            android:textColor="@color/w2c_text_on_dark"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            android:textAllCaps="false"
+            android:stateListAnimator="@null" />
+
+        <!-- Footer hint -->
         <TextView
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Wi-Fi Scanning" />
-
-        <Button
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Start Scan"
-            android:id="@+id/start"/>
-
-        <Button
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Stop Scan"
-            android:id="@+id/stop"/>
-
-        <Button
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Take a Guess"
-            android:id="@+id/guess"/>
+            android:layout_marginTop="18dp"
+            android:text="@string/w2c_hint"
+            android:textColor="@color/w2c_text_secondary"
+            android:textSize="11sp"
+            android:lineSpacingExtra="2dp" />
 
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -1,12 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    
+
     <!-- COMMON -->
     <color name="white">#ffffff</color>
     <color name="darker_gray">#121212</color>
 
-    <!-- LED -->
+    <!-- wifi2cot modern palette -->
+    <color name="w2c_surface">#15181B</color>
+    <color name="w2c_surface_alt">#1C2024</color>
+    <color name="w2c_stroke">#2A2F35</color>
 
-    <!-- PRESET -->
+    <color name="w2c_text_primary">#F5F7FA</color>
+    <color name="w2c_text_secondary">#8B939C</color>
+
+    <color name="w2c_accent">#1ED5A6</color>
+    <color name="w2c_accent_pressed">#15A382</color>
+    <color name="w2c_accent_soft">#0F2E27</color>
+
+    <color name="w2c_danger">#E5484D</color>
+    <color name="w2c_danger_pressed">#B5393D</color>
+
+    <color name="w2c_neutral">#232830</color>
+    <color name="w2c_neutral_pressed">#2E353F</color>
+    <color name="w2c_disabled">#2A2E33</color>
+    <color name="w2c_disabled_text">#5A626B</color>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,15 @@
     <!-- description -->
     <string name="app_desc">Grab RSSI values from local Access Points and try to guess where they are.</string>
 
+    <!-- UI -->
+    <string name="w2c_title">WIFI2COT</string>
+    <string name="w2c_subtitle">Access-point geolocation</string>
+    <string name="w2c_status_idle">Idle — press Start to scan</string>
+    <string name="w2c_start">Start scan</string>
+    <string name="w2c_stop">Stop scan</string>
+    <string name="w2c_compute">Compute &amp; plot</string>
+    <string name="w2c_hint">Tip: walk a loop around the area for the best fix. Disable Wi-Fi scan throttling in Developer options for faster scans.</string>
+
 
 
 

--- a/app/src/test/java/com/atakmap/android/wifi2cot/TrilaterationTest.java
+++ b/app/src/test/java/com/atakmap/android/wifi2cot/TrilaterationTest.java
@@ -1,0 +1,119 @@
+
+package com.atakmap.android.wifi2cot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit tests for the access-point position estimator. These run on a plain JVM
+ * because {@link Trilateration} has no Android dependencies.
+ */
+public class TrilaterationTest {
+
+    private static final double M_PER_DEG_LAT = 111_320.0;
+    private static final double REF = Trilateration.DEFAULT_REF_RSSI_1M;
+    private static final int FREQ = 2412; // 2.4 GHz channel 1
+
+    /** Build a synthetic reading whose RSSI is consistent with the path-loss model. */
+    private static Sample sampleObservedFrom(double obsLat, double obsLng,
+            double apLat, double apLng) {
+        double mPerDegLng = M_PER_DEG_LAT * Math.cos(Math.toRadians(obsLat));
+        double dx = (apLng - obsLng) * mPerDegLng;
+        double dy = (apLat - obsLat) * M_PER_DEG_LAT;
+        double dist = Math.max(1.0, Math.hypot(dx, dy));
+        double n = Trilateration.PATH_LOSS_2G;
+        int rssi = (int) Math.round(REF - 10.0 * n * Math.log10(dist));
+        return new Sample(rssi, FREQ, obsLat, obsLng, Double.NaN, "AA:BB", "test", 0L);
+    }
+
+    private static double metresBetween(double lat1, double lng1, double lat2, double lng2) {
+        double mPerDegLng = M_PER_DEG_LAT * Math.cos(Math.toRadians(lat1));
+        double dx = (lng2 - lng1) * mPerDegLng;
+        double dy = (lat2 - lat1) * M_PER_DEG_LAT;
+        return Math.hypot(dx, dy);
+    }
+
+    @Test
+    public void distanceIncreasesAsSignalWeakens() {
+        double near = Trilateration.rssiToDistance(-40, FREQ, REF);
+        double far = Trilateration.rssiToDistance(-80, FREQ, REF);
+        assertTrue("weaker signal must be further", far > near);
+        assertEquals("ref RSSI maps to ~1 m", 1.0,
+                Trilateration.rssiToDistance((int) REF, FREQ, REF), 0.01);
+    }
+
+    @Test
+    public void recoversApOffThePath() {
+        // Realistic "walk a loop" geometry: observations scattered in 2D around
+        // the area (NOT on a single line). The AP sits off to one side; a
+        // centroid could never leave the cluster, but trilateration should.
+        final double baseLat = 35.0, baseLng = -120.0;
+        final double mPerLng = M_PER_DEG_LAT * Math.cos(Math.toRadians(baseLat));
+
+        // AP at east=30 m, north=55 m from base.
+        double apLat = baseLat + 55.0 / M_PER_DEG_LAT;
+        double apLng = baseLng + 30.0 / mPerLng;
+
+        // Observer positions (east, north) metres — a loop-ish spread.
+        double[][] obs = {
+                {0, 0}, {50, 0}, {50, 40}, {0, 40},
+                {25, -30}, {-30, 20}, {70, 25}, {20, 70}
+        };
+
+        List<Sample> samples = new ArrayList<>();
+        for (double[] o : obs) {
+            double obsLat = baseLat + o[1] / M_PER_DEG_LAT;
+            double obsLng = baseLng + o[0] / mPerLng;
+            samples.add(sampleObservedFrom(obsLat, obsLng, apLat, apLng));
+        }
+
+        Trilateration.Estimate e = Trilateration.estimate(samples);
+        assertNotNull(e);
+        assertEquals("trilateration", e.method);
+        double err = metresBetween(e.lat, e.lng, apLat, apLng);
+        assertTrue("estimate within 15 m, was " + err + " m", err < 15.0);
+    }
+
+    @Test
+    public void straightLinePathFallsBackToCentroid() {
+        // A perfectly straight walking path leaves the perpendicular offset
+        // unobservable (singular normal matrix). The estimator must degrade
+        // gracefully to the centroid rather than emit a wild solution.
+        double apLat = 35.0 + 60.0 / M_PER_DEG_LAT;
+        double apLng = -120.0;
+        double mPerLng = M_PER_DEG_LAT * Math.cos(Math.toRadians(35.0));
+
+        List<Sample> samples = new ArrayList<>();
+        for (int i = -4; i <= 4; i++)
+            samples.add(sampleObservedFrom(35.0, -120.0 + (i * 25.0) / mPerLng, apLat, apLng));
+
+        Trilateration.Estimate e = Trilateration.estimate(samples);
+        assertNotNull(e);
+        assertEquals("centroid", e.method);
+    }
+
+    @Test
+    public void fallsBackToCentroidWhenCollinearWithTwoPoints() {
+        // Only two samples -> under-determined -> centroid fallback, no crash.
+        List<Sample> samples = new ArrayList<>();
+        samples.add(new Sample(-50, FREQ, 35.0, -120.0, Double.NaN, "AA", "t", 0L));
+        samples.add(new Sample(-60, FREQ, 35.0001, -120.0, Double.NaN, "AA", "t", 0L));
+
+        Trilateration.Estimate e = Trilateration.estimate(samples);
+        assertNotNull(e);
+        assertEquals("centroid", e.method);
+        assertTrue("centroid CE should be non-trivial", e.ce > 0);
+    }
+
+    @Test
+    public void emptyInputReturnsNull() {
+        assertEquals(null, Trilateration.estimate(new ArrayList<>()));
+        assertEquals(null, Trilateration.estimate(null));
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:8.7.3') {
+        classpath('com.android.tools.build:gradle:8.9.1') {
             exclude group: "net.sf.proguard", module: "proguard-gradle"
         }
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:7.4.2') {
+        classpath('com.android.tools.build:gradle:8.7.3') {
             exclude group: "net.sf.proguard", module: "proguard-gradle"
         }
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 android.useAndroidX=true
-android.bundle.enableUncompressedNativeLibs=false
 org.gradle.caching=false
 android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

Rewrites the access-point geolocation maths (which had a bug that prevented it from producing valid locations), modernizes the dropdown UI, and updates the build to target **ATAK 5.7** and compile cleanly on **tak.gov/user_builds**.

## Triangulation maths
- **Fix the core bug:** the per-BSSID weight array was sized one-per-AP, overwritten on each sample, then applied as a single scalar to every observation — the estimator could not produce a valid location.
- New `Trilateration.java`: weighted least-squares circle-intersection in a local east/north plane, log-distance path-loss ranging, received-power weighting, and a power-weighted centroid fallback for sparse/degenerate (e.g. straight-line) geometry. Unlike a centroid it can place the AP **off** the walked path.
- New `Sample.java` stores raw dBm + frequency (was lossy `100-abs(rssi)`).
- New `TrilaterationTest` — recovers a synthetic off-path AP to **<15 m**; covers straight-line fallback, two-sample, and empty input. All 5 tests pass.

## Data collection / lifecycle
- Snapshot GPS fix once per scan batch; `continue` past bad results instead of abandoning the batch.
- Numeric zero-coordinate check instead of `startsWith("0.0")` (which discarded valid coords).
- `ConcurrentHashMap` + `CopyOnWriteArrayList` + a single `ExecutorService` (was a new `Thread` per callback racing on a static map).
- Unregister the scan receiver and shut down the worker in `onDestroy` (was a leak).
- CoT: stable namespaced UID (updates instead of duplicating), real `ce`, `precisionlocation src=CALC`, dropped the bogus chat endpoint.

## UI
- Redesigned dark card layout: accent header, live status pill (`Scanning… N APs · M samples`), styled Start/Stop/Compute buttons with state-aware enable/disable.

## Build (ATAK 5.7 + tak.gov)
- `ATAK_VERSION 5.7.0`, takdev `3.+`, AGP `8.9.1`, Gradle `8.14.3`, Java `17`, `compileSdk 36`, minSdk `26`, targetSdk `34`, AGP-8 `namespace` (manifest `package` removed), modern `packagingOptions` + `jniLibs.useLegacyPackaging`, junit test dependency.
- **tak.gov build fixes:** removed `android.bundle.enableUncompressedNativeLibs` (removed in AGP 8.1, was aborting plugin application); `signingConfigs` now fall back to the build-generated `${buildDir}/android_keystore` when `local.properties` has no key entries, so it builds without throwing "No signing key configured!".

## Note
`app/key.jks` and `local.properties` (with signing passwords) are committed to the repo and are public — recommend `git rm --cached` + `.gitignore` and rotating the key. Excluded from the tak.gov source upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)